### PR TITLE
Fix sign-compare warnings

### DIFF
--- a/src/sdio_rp2350.cpp
+++ b/src/sdio_rp2350.cpp
@@ -592,7 +592,7 @@ sdio_status_t rp2350_sdio_rx_start(uint8_t *buffer, uint32_t num_blocks, uint32_
     {
         // Create DMA block descriptors to automatically start next block when previous
         // completes.
-        for (int i = 0; i < num_blocks; i++)
+        for (uint32_t i = 0; i < num_blocks; i++)
         {
             if (i > 0)
             {
@@ -660,7 +660,7 @@ static void sdio_update_rx_blocks_done()
         // reading the FIFO. But normally the checksum has already
         // been received during the IRQ latency.
         uint32_t start = SDIO_TIME_US();
-        int timeout = SDIO_CMD_TIMEOUT_US;
+        uint32_t timeout = SDIO_CMD_TIMEOUT_US;
         if (g_sdio.data_clock_hz > 0) timeout += 20 * 1000000 / g_sdio.data_clock_hz;
         while (pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_SM) < 3)
         {


### PR DESCRIPTION
```
src/sdio_rp2350.cpp: In function 'sdio_status_t rp2350_sdio_rx_start(uint8_t*, uint32_t, uint32_t)':
src/sdio_rp2350.cpp:595:27: warning: comparison of integer expressions of different signedness: 'int' and 'uint32_t' {aka 'long unsigned int'} [-Wsign-compare]
  595 |         for (int i = 0; i < num_blocks; i++)
      |                         ~~^~~~~~~~~~~~
src/sdio_rp2350.cpp:604:19: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  604 |             if (i < num_blocks - 1)
      |                 ~~^~~~~~~~~~~~~~~~
src/sdio_rp2350.cpp: In function 'void sdio_update_rx_blocks_done()':
src/sdio_rp2350.cpp:667:40: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  667 |             if (SDIO_ELAPSED_US(start) > timeout)
```

The `if (i > 0)` condition appears unnecessary (i.e. not intentional overflow), since if it was false the following lines would trash `g_sdio`.